### PR TITLE
Fix concept tagging on source text being blocked by annotation mode

### DIFF
--- a/components/text/ChapterDisplay.tsx
+++ b/components/text/ChapterDisplay.tsx
@@ -1515,6 +1515,10 @@ export default function ChapterDisplay({
   }
 
   function handleSelectWord(word: Word, shiftHeld = false) {
+    if (editingWordTags) {
+      handleToggleWordTagRef(word, shiftHeld);
+      return;
+    }
     if (editingAnnotations) {
       // Map the clicked word to its paragraph-segment first-word-id
       const segId = wordToParaStart.get(word.wordId) ?? word.wordId;
@@ -1559,10 +1563,6 @@ export default function ChapterDisplay({
     if (editingSpeech) {
       if (activeCharId === null) return;
       handleToggleSpeechSection(word, shiftHeld);
-      return;
-    }
-    if (editingWordTags) {
-      handleToggleWordTagRef(word, shiftHeld);
       return;
     }
     if (editingTc) {
@@ -3467,7 +3467,7 @@ export default function ChapterDisplay({
     scenes:      [],
     annotations: [],
     refs:        ["annotations", "indents", "rst"],
-    wordTags:    ["annotations", "indents", "rst"],
+    wordTags:    ["indents", "rst"],
   };
   function deactivateIncompatible(mode: string) {
     const keep = new Set([mode, ...(COMPAT[mode] ?? [])]);
@@ -3729,6 +3729,7 @@ export default function ChapterDisplay({
 
               {/* Line annotation mode */}
               {toolbarVis.annotations && <button
+                disabled={editingWordTags}
                 onClick={() => {
                   if (!editingAnnotations) deactivateIncompatible("annotations");
                   setEditingAnnotations((v) => !v);
@@ -3741,6 +3742,7 @@ export default function ChapterDisplay({
                   editingAnnotations
                     ? "bg-indigo-600 text-white"
                     : "bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-300 hover:bg-stone-200 dark:hover:bg-stone-700",
+                  "disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-stone-100 dark:disabled:hover:bg-stone-800",
                 ].join(" ")}
               >
                 ≡


### PR DESCRIPTION
## Summary
- Concept tagging worked on translation words but not source-language words: `handleSelectWord` in `ChapterDisplay.tsx` checked `editingAnnotations` before `editingWordTags`, and annotation mode could stay active alongside word-tag mode (the annotation toggle button was missing the `disabled={editingWordTags}` guard that its sibling buttons have, and `"annotations"` was listed as compatible with `"wordTags"` in the mode-exclusivity table). When both modes were active, clicks on source-text words were swallowed by the annotation-segment handler instead of toggling the word tag. Translation-word clicks go through a separate handler that never checked `editingAnnotations`, so tagging there always worked.
- Fix: check `editingWordTags` first in `handleSelectWord`, disable the annotation-mode toggle while word-tag mode is active, and drop `"annotations"` from `wordTags`' compatible list so entering word-tag mode also clears annotation mode.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manual click-through in browser (not possible in the sandbox used to author this fix — the Bible-text SQLite databases are gitignored binary assets not present there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JbQRCprKNi4BJ7VrZVEyxw)_